### PR TITLE
V3

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2024 Bertrand Laporte
+Copyright (c) 2023-2025 Bertrand Laporte
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -279,10 +279,13 @@ registerService<T>(iid: InterfaceId<T>, factory: () => T | Promise<T>): void;
 Examples:
 
 ```typescript
-// Register an object - factory will only be called once
+// Register an service - factory will only be called once
 asm.registerService(CalculatorIID, () => new CalculatorService());
 // Registration with async factory
 asm.registerService(MultiplierIID, async () => new MultiplierService());
+// Factory receive the calling context as argument
+asm.registerService(SomeServiceIID, (c: AsmContext) => new SomeService(c));
+
 // Register a function (as a service)
 asm.registerService(AdderIID, () => add); // add is a function
 ```

--- a/README.md
+++ b/README.md
@@ -1,27 +1,29 @@
 # asimo - asynchronous dependency manager
 
-Asimo is a micro libray that helps managing **JS objects & modules dependencies** (e.g. to share/retrieve objects or modules in a JS/TS code base). Asimo approach is different from traditional solutions like **Dependency Injection (DI)** libraries as its principle is to retrieve dependencies **on-demand** and **asynchronously** (which also allows to load the dependency module on-demand, thus the name ASYnchronous MOdule loader).
+Asimo is a micro libray that helps managing **JS objects & modules dependencies** (e.g. to share/retrieve objects or modules in a JS/TS code base). Asimo slightly differs from traditional **Dependency Injection (DI)** libraries as its principle is to retrieve dependencies **on-demand** and **asynchronously** (which also allows to load the dependency module on-demand, thus the name ASYnchronous MOdule loader). In some respects asimo follows the same principle as the [lazy.nvim] package manager.
+
+[lazy.nvim]: https://www.lazyvim.org/configuration/lazy.nvim
 
 Asimo was built from the following realizations:
 
--   **Advanced testing requires a _generic_ mechanism to replace code dependencies in test environments** (e.g. to use a fake _localStorage_ service to simulate different start state in an application).
--   **Dependency Injection is not well suited to progressive code load**, such as in client applications where large code bases cannot be loaded on application startup. With Dependency injections, all dependencies are loaded when a given entity is created which eventually results in large code packages (unless significant effort is made to prevent that issue). On the contrary, **asimo approach is to load dependencies on-demand**, which allows to reference rarely used functionalities anywhere in the application (with their type) without impacting the initial download, as the actual implementation will be loaded on-demand. Besides asimo allows to group JS modules into bundles independently from the code structure (in other words the code doesn't need special attention to support efficient progressive load)
+-   **Advanced testing requires a _generic_ mechanism to replace code dependencies in test environments** (e.g. to fake global services like _localStorage_ or _fetch_).
+-   Strict **Dependency Injection is not well suited to client-side applications** where large code bases cannot be loaded on application startup. With Dependency injections, all dependencies of a given entity needs to be loaded when the entity is created - which eventually results in large code packages (unless significant effort is made to prevent that issue). On the contrary, **asimo approach is to load dependencies on-demand**, which allows to easily reference frequently or rarely used functionalities in the same manner, without impacting the initial download. Besides, asimo allows to group JS modules into bundles independently from the code structure (in other words the code doesn't need special attention to support efficient progressive load)
 
 ## Why should you use asimo?
 
 Asimo helps solving 4 types of problems:
 
--   **unit testing**: asimo can replace dependencies with mock dependencies (e.g. in the test enviroment, unit tests can call a fake _fetch()_ that will return stable data).
+-   **client integration testing**: asimo can easily replace dependencies with mock dependencies (e.g. in the test enviroment, unit tests can call a fake _fetch()_ that will return stable data).
 -   **development**: asimo simplifies the development of _mock environment_ solutions that
-    simulate and synchronize multiple external dependencies (e.g. _fetch()_, _localStorage_, _SSE events_, etc.). The mock environment can define multiple profiles that will correspond to different datasets / behaviours. On top of that, the mock environment code can be loaded dynamically as an asimo bundle (i.e. through a dynamic import) and won't be packaged with the rest of the application. Last but not least this mock environment (mockenv) can be used for unit tests, development, demos and also for full client integration tests with tools like [Playwright] - more in the [asidemo] example
--   **application code splitting**: asimo allows to package the application into several bundles that will be downloaded on-demand, when one of its modules is required. This allows to improve the application startup time by optimizing the initial application load. Besides the application code is not aware of the bundle configuration that can be changed without any code refactoring.
--   **dependency sharing**: asimo can be used to implement a React-like context outside a JSX environment (as React context can only exist in a DOM-related environment). This allows to provide losely-coupled (but still typed) dependencies through a unique context object and comes in handy to reduce the number of variables to pass to the different parts of the code base.
+    simulate and synchronize multiple external dependencies (e.g. _fetch()_, _localStorage_, _SSE events_, etc.). The mock environment can define multiple profiles that will correspond to different datasets / behaviours. On top of that, the mock environment code can be loaded dynamically as an asimo bundle (i.e. through a dynamic import) and won't be packaged with the rest of the application. Last but not least this mock environment (mockenv) can be used for integration tests, development, demos and also for full client integration tests with tools like [Playwright] - more in the [asidemo] example
+-   **application code splitting**: asimo allows to package the application into several bundles that will be downloaded on-demand, when one of its modules is required. This allows to improve the application startup by optimizing the initial application load. Besides, the application code does not need to be aware of the bundle configuration that can be changed without any code refactoring.
+-   **application context**: asimo can be used to implement a React-like context outside any DOM-related environment (unlike React contexts). This allows to provide losely-coupled (but still typed) dependencies through a unique context object and comes in handy to reduce the number of variables to pass to the different parts of the code base.
 
 Live Demos: 🚀 [sample app architecture (asidemo)][asidemo] or [google search results][results]
 
 Presentation [slides]
 
-Other key features:
+Other important features:
 
 -   **design by interface**: depend on abstraction, not implementation - cf. [SOLID] design principles
 -   full and transparent **typescript support**
@@ -39,14 +41,14 @@ Like most dependency management systems, Asimo base principle is to create **dep
 
 ```typescript
 // retrieve the calculator service (asynchronous)
-const calc = await asm.get(CalculatorIID);
-//     CalculatorIID is the Calculator Interface Identifier
-//     asm is an Asimo dependency context
-//     calc is a Calculator service instance
+const calc = await asm.fetch(CalculatorIID);
+//   CalculatorIID is the Calculator Interface ID
+//   asm is an Asimo dependency context
+//   calc is a Calculator service instance
 
 // use it!
 const result = calc.add(1, 2);
-//     -> the service doesn't need to be async
+//   -> the service doesn't need to be async
 ```
 
 The **Dependency contexts** are objects on which **dependency factories** can be registered - e.g.
@@ -54,26 +56,26 @@ The **Dependency contexts** are objects on which **dependency factories** can be
 ```typescript
 // Service registration
 asm.registerService(CalculatorIID, () => new CalculatorService());
-//     of course CalculatorService must implement the interface associated
-//     to CalculatorIID --> typescript will help you there in case of error
+//   of course CalculatorService must implement the interface associated
+//   to CalculatorIID --> typescript will help you there in case of error
 ```
 
 Asimo supports 3 kinds of factories
 
--   **service factories** (cf. **_registerService()_**) that produce unique objects that will be shared by application modules - i.e. the service instance will be created on the first _get()_ call, and then asimo will always return this instance instead of creating a new one.
+-   **service factories** (cf. **_registerService()_**) that produce unique objects that will be shared by application modules - i.e. the service instance will be created on the first _fetch()_ call, and then asimo will always return this instance instead of creating a new one.
 -   **object factories** (cf. **_registerFactory()_**) that produce new object instances everytime they are called.
--   **group factories** (cf. **_registerGroup()_**) that are used to declare bundles (i.e. multiple JS modules that will be packaged together).
+-   **group factories** (cf. **_registerGroup()_**) that are used to declare bundles (i.e. multiple JS modules that will be packaged together and that will be loaded dynamically through dynamic imports).
 
-On top of that, asimo also supports registering any kind of objects. Note: in this case the retrieval methods are synchronous (cf. **_registerObject()_**, **_getObject()_** and **_fetchObject()_**)
+On top of that, asimo also supports registering any kind of **objects** that can be retrieved **synchronously** throught the **_get()_** method.
 
 ```typescript
 // Object registration
 const calc = new CalculatorService();
-asm.registerService(CalculatorIID, calc);
+asm.registerObject(CalculatorIID, calc);
 
-const calc2 = asm.getObject(CalculatorIID);
+const calc2 = asm.get(CalculatorIID);
 // calc2 is of type  Calculator (cf. below) and is equal to calc:
-expect(calc2).toBe(true);
+expect(calc2).toBe(calc);
 ```
 
 Last but not least, and like with any dependency management systems, asimo allows to **chain dependency contexts** by creating _sub-contexts_ - e.g.
@@ -90,9 +92,8 @@ Note: by default asimo creates a **root context** that is exposed as **asm** by 
 
 In this example, if an application module tries to retrieve a dependency on _context3_ asimo will first look in _context3_, then in _context2_ and then in _asm_ if it hasn't found it before. Asimo offers 2 methods to manage cases where dependency factories are not found (i.e. not registered):
 
--   either it **throws an exception** as the error results from a configuration issue that can only occurs at
-    development time because the factory registration is missing. The benefit is that the dependency user doesn't need to check the object returned by asimo. This behavior is implemented by the _get()_ method.
--   or it **returns null** and the dependency user will have to manage the case where the returned object is not available (typescript will show that the type can be null). This behavior is implemented by the _retrieve()_ method.
+-   either it **throws an exception** (if not default values are provided or if _get_ or _fetch_ are used to retrieve multiple dependencies in one call)
+-   or it **returns a default value** and the caller will have to manage the case where the returned object is not available (typescript will show that the type can be null).
 
 The last _special_ part that needs to be mentioned concerns the **interface definitions**. As typescript interfaces cannot be read at runtime, asimo exposes a special **interfaceId()** method that allows to bind a typescript interface with a string (that should be unique - this is why we suggest to use namespaces):
 
@@ -104,15 +105,15 @@ export interface Calculator {
 }
 
 // interface id token associated to the typescript interface
-export const CalculatorIID = interfaceId<Calculator>("asimo.src.tests.Calculator");
-// asimo.src.tests.Calculator -> unique namespace (by construction)
+export const CalculatorIID = interfaceId<Calculator>("asimo.tests.Calculator");
+// asimo.tests.Calculator -> unique namespace
 ```
 
 ## Examples
 
 In all use cases asimo involves at least 2 modules:
 
--   a **consumer** module that retrieves the producers dynamically, on-demand (the consumer can then keep a reference to its dependencies to avoid further async calls if need be):
+-   a **consumer** module that retrieves dependencies dynamically (the consumer can then keep a reference to its dependencies to avoid further async calls if need be):
 
 ```typescript
 // Consumer
@@ -126,7 +127,7 @@ async function doSomething() {
 }
 ```
 
--   a **producer** module that contains services or factories that will be exposed to consumers. Producers are usually split in 2 files:
+-   a **producer** module that contains object or service factories that will be exposed to consumers. Producers are usually split in 2 files:
 
 -- a _type_ file:
 
@@ -215,58 +216,61 @@ export const AdderIID = interfaceId<Adder>("asimo.src.tests.Adder");
 
 The AsmContext is the object that contains the registered factories and that exposes all asimo APIs (but `interfaceId()`):
 
-### `get()`
+### `fetch()`
 
-Retrieve a service or an object instance. For each interface id, asimo will first look in the current
-context for services or object factories or groups (in this order) - if not found
-it will then perform the same lookup in its parent context, recursively up to the root context).
+Retrieve a service or an object instance asynchronously. For each interface id passed as argument, asimo will first look in the current context for services or object factories or groups (in this order) - if not found
+it will then perform the same lookup in its parent context, recursively up to the root context.
 This method allows to retrieve up to 5 dependencies in one call with type support (more can be retrieved
 without type inference - cf. call signature).
 
-Note: **get() will throw exceptions if the factory is not defined** for the expected interface. This is usually the preferred behavior as a missing factory generally results from an application configuration issue that is fixed at development time. Thanks to this behavior the dependency user doesn't need to check the type returned by asimo.
-
-Note 2: the parameters can be either `InterfaceId` objects or interface namespaces (strings).
-When using `InterfaceId` typescript will automatically infer the right type - otherwise an explicit
-type cast will be necessary, as shown below
-
-Examples:
+Note: **if the factory is not defined fetch will throw an exceptioin unless a default value is passed as 2nd argument**.
 
 ```typescript
-// Get one dependency
-const calc = await asm.get(CalculatorIID);
-calc.add(1, 2); // calc2 type is Calculator
-
-// Get one dependency by namesapce
-const calc2 = await asm.get("asimo.src.tests.Calculator");
-(calc2 as Calculator).add(1, 2); // calc2 type is unknown
-
-// Retrieve multiple dependencies - also works with namespace strings:
-const [m, c, a] = await asm.get(MultiplierIID, CalculatorIID, AdderIID);
-```
-
-### `fetch()`
-
-This method is similar to _get()_ with the difference that it will return _null_ if the dependency is not found (instead of throwing an exception).
-
-```typescript
-// Get one dependency
+// Get one dependency - throws if not found
 const calc = await asm.fetch(CalculatorIID);
-calc?.add(1, 2); // calc2 type is Calculator | null
+calc.add(1, 2); // calc type is Calculator
+
+// Get one dependency - return the default value if not found
+const calc2 = await asm.fetch(CalculatorIID, null);
+calc2?.add(1, 2); // calc2 type is Calculator | null
 
 // Retrieve one dependency by namesapce
-const calc2 = await asm.fetch("asimo.src.tests.Calculator");
-(calc2 as Calculator)!.add(1, 2); // calc2 type is unknown
+const calc3 = await asm.fetch("asimo.tests.Calculator");
+(calc3 as Calculator)!.add(1, 2); // calc3 type is unknown
 
 // Retrieve multiple dependencies - also works with namespace strings:
 const [m, c, a] = await asm.fetch(MultiplierIID, CalculatorIID, AdderIID);
-//     m is of type Multiplier
-//     c is of type Calculator
-//     a is of type Adder
+//   m is of type Multiplier
+//   c is of type Calculator
+//   a is of type Adder
+```
+
+### `get()`
+
+Get an object from an asimo context (or its parents). On the contrary to _fetch()_, _get()_ is **synchronous** and only returns objects that have been registered through _registerObject()_. This function will throw an error if no default value is passed as 2nd argument.
+
+```typescript
+// register an the object
+asm.registerObject(CalculatorIID, new CalculatorService());
+
+// Get one dependency - throws if not found
+const calc = asm.get(CalculatorIID);
+calc.add(1, 2); // calc type is Calculator
+
+// Get one dependency - return the default value if not found
+const calc2 = asm.get(CalculatorIID, null);
+calc2?.add(1, 2); // calc2 type is Calculator | null
+
+// Retrieve multiple dependencies - also works with namespace strings:
+const [m, c, a] = asm.get(MultiplierIID, CalculatorIID, AdderIID);
+//   m is of type Multiplier
+//   c is of type Calculator
+//   a is of type Adder
 ```
 
 ### `registerService()`
 
-Register a Service (i.e. a singleton object or function). The service doesn't need to be instantiated at registration time as we need to provide a factory function (synchronous or asynchronous). Note: **service factories are only called once** whereas object factories are called at each _get()_ (or _fetch()_) in order to generate new object instances.
+Register a Service (i.e. a singleton object or function). The service doesn't need to be instantiated at registration time as we need to provide a factory function as parameter (synchronous or asynchronous). Note: **service factories are only called once** whereas object factories are called at each _fetch()_ in order to generate new object instances.
 
 ```typescript
 registerService<T>(iid: InterfaceId<T>, factory: () => T | Promise<T>): void;
@@ -279,18 +283,15 @@ Examples:
 asm.registerService(CalculatorIID, () => new CalculatorService());
 // Registration with async factory
 asm.registerService(MultiplierIID, async () => new MultiplierService());
-// Register a function - cf. above
-asm.registerService(AdderIID, () => add);
-//     m is of type Multiplier | null
-//     c is of type Calculator | null
-//     a is of type Adder | null
+// Register a function (as a service)
+asm.registerService(AdderIID, () => add); // add is a function
 ```
 
 ### `registerFactory()`
 
-Register an object factory. The factory will be called any time the get method is called
+Register an object factory. The factory will be called any time the _fetch()_ method is called
 for the object's interface id. On the contrary to services, there is no restriction on the number
-of objects that can be creatd. Besides asimo doesn't keep any reference to the object
+of objects that can be creatd. Besides asimo doesn't keep any reference to the object (no risks of memory leak)
 
 ```typescript
 registerFactory<T>(iid: InterfaceId<T>, factory: () => T | Promise<T>): void;
@@ -305,7 +306,7 @@ asm.registerFactory(MultiplierIID, () => new MultiplierImpl());
 
 ### `registerObject()`
 
-Register any kind of object in the given context.
+Register any kind of object in the given context - these objects will be accessible synchronously through the _get()_ method
 
 ```typescript
 interface SimpleObject {
@@ -323,25 +324,15 @@ const o: SimpleObject = {
 context.registerObject(SimpleObjectIID, o);
 
 // retrieval is synchronous for objects (no await)
-const o2 = context.getObject(SimpleObjectIID); // o2 type is SimpleObject
+const o2 = context.get(SimpleObjectIID); // o2 type is SimpleObject
 expect(o2).toBe(o);
-const o3 = context.fetchObject(SimpleObjectIID); // o3 type is SimpleObject | null
-expect(o3).toBe(o);
 ```
-
-### `getObject()`
-
-Get an object from the given context (or its parent). This function will throw an error if no object is defined (on the contrary to _*fetchObject()*_) - cf. previous example.
-
-### `fetchObject()`
-
-Get an object from the given context (or its parent). This function will return null if no object is defined (on the contrary to _*getObject()*_) - cf. previous example.
 
 ### `registerGroup()`
 
 Register a group loader that will be used to asynchronously load multiple
 services and object factories gathered in a same **deployment bundle**. The bundle code will be loaded on-demand, when
-an explicit `get()/fetch()` is done on one of its service or object interfaces.
+an explicit `fetch()` is done on one of its service or object interfaces.
 
 Parameters:
 
@@ -357,12 +348,12 @@ Example:
 ```typescript
 // Register several interface implementation that will be loaded on-demand through
 // a dynamic module import (this assumes that the implementaion are defined in the module)
-asm.registerGroup([Service1IID, Object2IID], () => import("./groups/groupA"));
+asm.registerGroup([Service1IID, Object2IID], () => import("./groups/mybundlefiile"));
 ```
 
 ### `createChildContext()`
 
-Create a child context that can override some of the dependencies defined in its parent (cf. get behaviour)
+Create a child context that can override some of the dependencies defined in its parent (cf. _fetch()_ and _get()_)
 
 ```typescript
 createChildContext(name?:string): AsmContext;
@@ -422,18 +413,42 @@ const defs = asm.definitions;
 // ]
 ```
 
-### `consoleOutput`
+### `logState`
 
-Tell asimo how console logs should be handled - 2 possible values: `""` or `"Errors"`
+Log a given context state (i.e. list of registered dependencies) into and array or to the `logger` (console by default) if not _output_ argument is provided.
 
--   `""`: no logs
--   `"Errors"`: log errors (e.g. invalid arguments or invalid resolution) [**default**]
+```typescript
+logState(output?: string[]): void;
+```
+
+Example:
+
+```typescript
+mycontext.logState();
+```
+
+```bash
+# console output:
+Context /asm/test/mycontext:
++ asimo.src.tests.Calculator [service]: not loaded
++ asimo.src.tests.Multiplier [service]: loaded
+Context /asm/test:
++ asimo.src.tests.Calculator [service]: loaded
+Context /asm:
++ asimo.src.tests.Calculator [service]: not loaded
++ asimo.src.tests.Adder [service]: not loaded
++ asimo.src.tests.Multiplier [object]
+```
+
+### `logger`
+
+Tell asimo where to log errors - default value is `console` but can also be `null` to avoid logging anything
 
 Note: this setting is global, even if set on a child context.
 Example:
 
 ```typescript
-asm.consoleOutput = ""; // deactivate error logs
-// [...]
-asm.consoleOutput = "Errors"; // reactivate error logs
+asm.logger = null; // deactivate error logs
+// [some code here ...]
+asm.logger = console; // reactivate error logs
 ```

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     },
     "devDependencies": {
         "rimraf": "6.0.1",
-        "typescript": "^5.8.2",
-        "vite": "^6.2.3",
-        "vitest": "^3.0.9"
+        "typescript": "^5.8.3",
+        "vite": "^6.2.5",
+        "vitest": "^3.1.1"
     },
     "packageManager": "yarn@3.6.1+sha512.de524adec81a6c3d7a26d936d439d2832e351cdfc5728f9d91f3fc85dd20b04391c038e9b4ecab11cae2b0dd9f0d55fd355af766bc5c1a7f8d25d96bb2a0b2ca"
 }

--- a/package.json
+++ b/package.json
@@ -22,10 +22,13 @@
         "dependency injection",
         "DI",
         "test",
+        "React context",
         "progressive load",
+        "dynamic import",
         "application packaging",
         "module",
-        "module loader"
+        "module loader",
+        "lazy package manager"
     ],
     "scripts": {
         "clean": "rimraf dist lib",

--- a/src/__tests__/asyncincrementor.ts
+++ b/src/__tests__/asyncincrementor.ts
@@ -1,5 +1,5 @@
 import { asm, interfaceId } from "../asimo";
-import { AsmContext } from "../types";
+import { AsmContext } from "../asimo.types";
 import { Calculator, CalculatorIID } from "./types";
 
 /**

--- a/src/__tests__/asyncincrementor.ts
+++ b/src/__tests__/asyncincrementor.ts
@@ -18,10 +18,12 @@ export class _AsyncIncrementorService implements AsyncIncrementor {
 
     async increment(n: number) {
         if (!this.di) throw "Not DI context";
-        return (await this.di.get(CalculatorIID))!.add(n, this.offset);
+        return (await this.di.fetch(CalculatorIID))!.add(n, this.offset);
     }
 }
 
 // NB: interface and registration should be defined in separate files to benefit from on-demand module load
-export const AsyncIncrementorIID = interfaceId<AsyncIncrementor>("asimo.src.tests.AsyncIncrementor");
+export const AsyncIncrementorIID = interfaceId<AsyncIncrementor>(
+    "asimo.src.tests.AsyncIncrementor",
+);
 asm.registerService(AsyncIncrementorIID, () => new _AsyncIncrementorService());

--- a/src/__tests__/groups.spec.ts
+++ b/src/__tests__/groups.spec.ts
@@ -43,11 +43,11 @@ describe("Groups", () => {
             { iid: "asimo.src.tests.groups.Object2", type: "group" }, // factory not loaded
         ]);
 
-        const s1 = await asm.get(Service1IID);
+        const s1 = await asm.fetch(Service1IID);
         expect(groupALoadCount).toBe(1);
         expect(s1.name).toBe("Service1");
         expect(s1.add(40, 2)).toBe(42);
-        const s1bis = await asm.get(Service1IID);
+        const s1bis = await asm.fetch(Service1IID);
         expect(groupALoadCount).toBe(1);
         expect(s1).toBe(s1bis);
 
@@ -59,11 +59,11 @@ describe("Groups", () => {
             { iid: "asimo.src.tests.groups.Object2", type: "object" }, // factory loaded
         ]);
 
-        const o2 = await asm.get(Object2IID);
+        const o2 = await asm.fetch(Object2IID);
         expect(o2.name).toBe("Object2");
         expect(o2.multiply(3, 2)).toBe(6);
 
-        const o2bis = await asm.get(Object2IID);
+        const o2bis = await asm.fetch(Object2IID);
         expect(o2bis.name).toBe("Object2");
         expect(o2bis.multiply(3, 2)).toBe(6);
         expect(o2bis).not.toBe(o2);
@@ -73,20 +73,20 @@ describe("Groups", () => {
     it("should support group loaders (subcontext)", async () => {
         asm.registerGroup([Service1IID, Object2IID], () => import("./groups/groupAbis"));
         groupALoadCount = 0;
-        const s1 = await asm.get(Service1IID);
+        const s1 = await asm.fetch(Service1IID);
         expect(groupALoadCount).toBe(1);
         expect(s1.name).toBe("Service1");
         expect(s1.add(40, 2)).toBe(42);
-        const s1bis = await asm.get(Service1IID);
+        const s1bis = await asm.fetch(Service1IID);
         expect(groupALoadCount).toBe(1);
         expect(s1).toBe(s1bis);
 
-        const o2 = await asm.get(Object2IID);
+        const o2 = await asm.fetch(Object2IID);
         expect(groupALoadCount).toBe(1);
         expect(o2.name).toBe("Object2");
         expect(o2.multiply(3, 2)).toBe(6);
 
-        const o2bis = await asm.get(Object2IID);
+        const o2bis = await asm.fetch(Object2IID);
         expect(groupALoadCount).toBe(1);
         expect(o2bis.name).toBe("Object2");
         expect(o2bis.multiply(3, 2)).toBe(6);
@@ -96,17 +96,17 @@ describe("Groups", () => {
     it("should only load group once in case of parallel requests", async () => {
         asm.registerGroup([Service1IID, Object2IID], () => import("./groups/groupAter"));
         groupALoadCount = 0;
-        const [s1, o2] = await asm.get(Service1IID, Object2IID);
+        const [s1, o2] = await asm.fetch(Service1IID, Object2IID);
         expect(groupALoadCount).toBe(1);
         expect(s1.name).toBe("Service1");
         expect(s1.add(40, 2)).toBe(42);
-        const s1bis = await asm.get(Service1IID);
+        const s1bis = await asm.fetch(Service1IID);
         expect(groupALoadCount).toBe(1);
         expect(s1).toBe(s1bis);
         expect(o2.name).toBe("Object2");
         expect(o2.multiply(3, 2)).toBe(6);
 
-        const o2bis = await asm.get(Object2IID);
+        const o2bis = await asm.fetch(Object2IID);
         expect(groupALoadCount).toBe(1);
         expect(o2bis.name).toBe("Object2");
         expect(o2bis.multiply(3, 2)).toBe(6);

--- a/src/__tests__/logs.spec.ts
+++ b/src/__tests__/logs.spec.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { interfaceId, asm as rsm } from "../asimo";
 import { AsmContext } from "../types";
 import { _CalculatorService } from "./calculator";
-import { Adder } from "./adder";
+import { Adder, AdderIID } from "./adder";
 import { CalculatorIID } from "./types";
 
 describe("Asimo Logs", () => {
@@ -12,7 +12,6 @@ describe("Asimo Logs", () => {
     const console1 = globalThis.console;
 
     const AdderIID2 = interfaceId<Adder>("asimo.src.tests.Adder2");
-    const AdderIID3 = interfaceId<Adder>("asimo.src.tests.Adder3");
 
     function mockGlobalConsole() {
         globalThis.console = Object.create(console1, {
@@ -102,7 +101,36 @@ describe("Asimo Logs", () => {
         logs = [];
     });
 
-    it("should log errors when factory don't output objects or functions", async () => {});
+    it("should log errors when get doesn't find one or multipe object", async () => {
+        asm.registerObject(CalculatorIID, {} as any);
+        let err = "";
+        try {
+            asm.get(AdderIID2);
+        } catch (ex) {
+            err = ex.message;
+        }
+        expect(logs.join(";")).toBe('ASM [/asm/test] Object not found: "asimo.src.tests.Adder2"');
+
+        logs = [];
+        err = "";
+        try {
+            asm.get(CalculatorIID, AdderIID2);
+        } catch (ex) {
+            err = ex.message;
+        }
+        expect(logs.join(";")).toBe('ASM [/asm/test] Object not found: "asimo.src.tests.Adder2"');
+
+        logs = [];
+        err = "";
+        try {
+            asm.get(AdderIID, AdderIID2);
+        } catch (ex) {
+            err = ex.message;
+        }
+        expect(logs.join(";")).toBe(
+            'ASM [/asm/test] Objects not found: ["asimo.src.tests.Adder", "asimo.src.tests.Adder2"]',
+        );
+    });
 
     it("should not log when consoleOutput is empty", async () => {
         asm.consoleOutput = "";

--- a/src/__tests__/logs.spec.ts
+++ b/src/__tests__/logs.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { interfaceId, asm as rsm } from "../asimo";
-import { AsmContext } from "../types";
+import { AsmContext } from "../asimo.types";
 import { _CalculatorService } from "./calculator";
 import { Adder, AdderIID } from "./adder";
 import { CalculatorIID } from "./types";
@@ -48,6 +48,7 @@ describe("Asimo Logs", () => {
         mockGlobalConsole();
         logs = [];
         asm = createContext();
+        asm.logger = globalThis.console;
     });
 
     afterEach(() => {
@@ -137,8 +138,8 @@ describe("Asimo Logs", () => {
         );
     });
 
-    it("should not log when consoleOutput is empty", async () => {
-        asm.consoleOutput = "";
+    it("should not log when logger is null", async () => {
+        asm.logger = null;
         expect(logs.join("")).toBe("");
         try {
             await asm.fetch("asimo.src.tests.Calc123");
@@ -150,7 +151,7 @@ describe("Asimo Logs", () => {
             expect(add).toBe(null);
         } catch (ex) {}
         expect(logs.join("")).toBe("");
-        asm.consoleOutput = "Errors";
+        asm.logger = console;
     });
 
     it("should validate iids", async () => {

--- a/src/__tests__/main.spec.ts
+++ b/src/__tests__/main.spec.ts
@@ -130,6 +130,20 @@ describe("Asimo", () => {
         expect(calc?.numberOfCalls).toBe(1);
     });
 
+    it("should pass the context to factories", async () => {
+        // create a 2nd interface id for the calculator
+        const CalcIID = interfaceId<Calculator>("asimo.src.tests.Calc");
+        let factoryContext: any = null;
+        context.registerService(CalcIID, async (c: AsmContext) => {
+            factoryContext = c;
+            return new _CalculatorService();
+        });
+
+        const calc = await context.fetch(CalcIID)!;
+        expect(calc?.add(21, 21)).toBe(42);
+        expect(factoryContext).toBe(context);
+    });
+
     it("should delegate creation to parent context", async () => {
         const calc1 = await context.fetch(CalculatorIID)!;
         calc1?.add(1, 2);
@@ -413,8 +427,6 @@ describe("Asimo", () => {
     });
 
     // TODO
-    // support mechanism for service to expose multiple interfaces
     // factory crash error
-    // error management / throwOnError / errLogger
     // 2 different interface id objects with the same namespace should resolve to the same object
 });

--- a/src/__tests__/main.spec.ts
+++ b/src/__tests__/main.spec.ts
@@ -18,7 +18,7 @@ describe("Asimo", () => {
         c.registerService(SyncIncrementorIID, () => new _SyncIncrementorService());
         c.registerService(AsyncIncrementorIID, () => new _AsyncIncrementorService());
         c.registerService(AdderIID, () => _add);
-        c.consoleOutput = "";
+        c.logger = null;
         return c;
     }
 
@@ -153,17 +153,17 @@ describe("Asimo", () => {
     });
 
     it("should return null for unknown interfaces", async () => {
-        const aco = context.consoleOutput;
+        const lg = context.logger;
         const CalcIID = interfaceId<Calculator>("asimo.src.tests.Calc");
 
-        context.consoleOutput = "";
+        context.logger = null;
         let err = "";
         try {
             const calc = await context.fetch(CalcIID)!;
         } catch (ex) {
             err = ex.message;
         }
-        context.consoleOutput = aco;
+        context.logger = lg;
         expect(err).toBe('ASM [/asm/test] Interface not found: "asimo.src.tests.Calc"');
     });
 

--- a/src/__tests__/main.spec.ts
+++ b/src/__tests__/main.spec.ts
@@ -18,6 +18,7 @@ describe("Asimo", () => {
         c.registerService(SyncIncrementorIID, () => new _SyncIncrementorService());
         c.registerService(AsyncIncrementorIID, () => new _AsyncIncrementorService());
         c.registerService(AdderIID, () => _add);
+        c.consoleOutput = "";
         return c;
     }
 
@@ -76,7 +77,7 @@ describe("Asimo", () => {
             { iid: "asimo.src.tests.Multiplier", type: "object" },
         ]);
 
-        const calc = await c.get(CalculatorIID);
+        const calc = await c.fetch(CalculatorIID);
         expect(c.definitions).toMatchObject([
             { iid: "asimo.src.tests.Calculator", type: "service", loaded: true }, // now loaded
             { iid: "asimo.src.tests.SyncIncrementor", type: "service", loaded: false },
@@ -94,8 +95,8 @@ describe("Asimo", () => {
 
         expect(c1).not.toBe(c2);
 
-        const s1 = await c1.get(CalculatorIID);
-        const s2 = await c2.get(CalculatorIID);
+        const s1 = await c1.fetch(CalculatorIID);
+        const s2 = await c2.fetch(CalculatorIID);
 
         expect(s1).not.toBe(s2);
 
@@ -107,11 +108,11 @@ describe("Asimo", () => {
         expect(s2!.add(1, 2)).toBe(3);
         expect(s2?.numberOfCalls).toBe(1);
 
-        const s1bis = await c1.get(CalculatorIID)!;
+        const s1bis = await c1.fetch(CalculatorIID)!;
         expect(s1bis).toBe(s1);
         expect(s1bis?.numberOfCalls).toBe(1);
 
-        const s = await context.get(CalculatorIID)!;
+        const s = await context.fetch(CalculatorIID)!;
         expect(s).not.toBe(s1);
         expect(s).not.toBe(s2);
         expect(s?.numberOfCalls).toBe(0);
@@ -122,7 +123,7 @@ describe("Asimo", () => {
         const CalcIID = interfaceId<Calculator>("asimo.src.tests.Calc");
         context.registerService(CalcIID, async () => new _CalculatorService());
 
-        const calc = await context.get(CalcIID)!;
+        const calc = await context.fetch(CalcIID)!;
 
         expect(calc?.numberOfCalls).toBe(0);
         expect(calc?.add(21, 21)).toBe(42);
@@ -130,22 +131,22 @@ describe("Asimo", () => {
     });
 
     it("should delegate creation to parent context", async () => {
-        const calc1 = await context.get(CalculatorIID)!;
+        const calc1 = await context.fetch(CalculatorIID)!;
         calc1?.add(1, 2);
 
         const c1 = context.createChildContext();
-        const calc2 = await c1.get(CalculatorIID)!;
+        const calc2 = await c1.fetch(CalculatorIID)!;
 
         expect(calc2).toBe(calc1);
         expect(calc2?.numberOfCalls).toBe(1);
     });
 
     it("should support get with string namespaces", async () => {
-        const calc1 = await context.get(CalculatorIID.ns);
+        const calc1 = await context.fetch(CalculatorIID.ns);
         (calc1 as Calculator).add(1, 2);
 
         const c1 = context.createChildContext();
-        const calc2 = await c1.get(CalculatorIID)!;
+        const calc2 = await c1.fetch(CalculatorIID)!;
 
         expect(calc2).toBe(calc1);
         expect(calc2?.numberOfCalls).toBe(1);
@@ -158,12 +159,12 @@ describe("Asimo", () => {
         context.consoleOutput = "";
         let err = "";
         try {
-            const calc = await context.get(CalcIID)!;
+            const calc = await context.fetch(CalcIID)!;
         } catch (ex) {
             err = ex.message;
         }
         context.consoleOutput = aco;
-        expect(err).toBe('[Dependency Context] Interface "asimo.src.tests.Calc" not found in /asm');
+        expect(err).toBe('ASM [/asm/test] Interface not found: "asimo.src.tests.Calc"');
     });
 
     describe("Invalid factories", () => {
@@ -172,7 +173,7 @@ describe("Asimo", () => {
             const CalcIID = interfaceId<Calculator>("asimo.src.tests.Calc");
             context.registerService(CalcIID, () => undefined);
 
-            const calc = await context.get(CalcIID)!;
+            const calc = await context.fetch(CalcIID, null)!;
 
             expect(calc).toBe(null);
         });
@@ -182,36 +183,44 @@ describe("Asimo", () => {
             const CalcIID = interfaceId<Calculator>("asimo.src.tests.Calc");
             context.registerService(CalcIID, async () => undefined);
 
-            const calc = await context.get(CalcIID)!;
+            const calc = await context.fetch(CalcIID, null)!;
 
             expect(calc).toBe(null);
         });
 
-        it("should return null when factory does not return an object", async () => {
+        it("should throw when factory does not return an object", async () => {
             // create a 2nd interface id for the calculator
             const CalcIID = interfaceId<Calculator>("asimo.src.tests.Calc");
             context.registerService(CalcIID, () => 123 as any);
 
-            const calc = await context.get(CalcIID)!;
-
-            expect(calc).toBe(null);
+            let msg = "";
+            try {
+                const calc = await context.fetch(CalcIID);
+            } catch (ex) {
+                msg = ex.message;
+            }
+            expect(msg).toBe('ASM [/asm/test] Interface not found: "asimo.src.tests.Calc"');
         });
 
-        it("should return null when async factory does not return an object", async () => {
+        it("should throw when async factory does not return an object", async () => {
             // create a 2nd interface id for the calculator
             const CalcIID = interfaceId<Calculator>("asimo.src.tests.Calc");
             context.registerService(CalcIID, async () => 123 as any);
 
-            const calc = await context.get(CalcIID)!;
-
-            expect(calc).toBe(null);
+            let msg = "";
+            try {
+                const calc = await context.fetch(CalcIID)!;
+            } catch (ex) {
+                msg = ex.message;
+            }
+            expect(msg).toBe('ASM [/asm/test] Interface not found: "asimo.src.tests.Calc"');
         });
     });
 
     describe("Sync style service dependencies", () => {
         it("should load a service with a custom context", async () => {
-            const calc = (await context.get(CalculatorIID))!;
-            const inc = (await context.get(SyncIncrementorIID))!;
+            const calc = (await context.fetch(CalculatorIID))!;
+            const inc = (await context.fetch(SyncIncrementorIID))!;
 
             await inc.init(context);
 
@@ -224,9 +233,9 @@ describe("Asimo", () => {
         });
 
         it("should load a service with the default context", async () => {
-            const rootCalc = (await rsm.get(CalculatorIID))!;
-            const calc = (await context.get(CalculatorIID))!;
-            const inc = (await context.get(SyncIncrementorIID))!;
+            const rootCalc = (await rsm.fetch(CalculatorIID))!;
+            const calc = (await context.fetch(CalculatorIID))!;
+            const inc = (await context.fetch(SyncIncrementorIID))!;
 
             await inc.init(); // no args => rootAsm will be used
 
@@ -242,15 +251,15 @@ describe("Asimo", () => {
         });
 
         it("should support function services", async () => {
-            const add = await context.get(AdderIID);
+            const add = await context.fetch(AdderIID);
             expect(add(39, 3)).toBe(42);
         });
     });
 
     describe("Async style service dependencies", () => {
         it("should load a service with a custom context", async () => {
-            const calc = (await context.get(CalculatorIID))!;
-            const inc = (await context.get(AsyncIncrementorIID))!;
+            const calc = (await context.fetch(CalculatorIID))!;
+            const inc = (await context.fetch(AsyncIncrementorIID))!;
 
             inc.di = context;
 
@@ -262,9 +271,9 @@ describe("Asimo", () => {
             expect(calc.numberOfCalls).toBe(2); // calc service was called
         });
         it("should load a service with the default context", async () => {
-            const rootCalc = (await rsm.get(CalculatorIID))!;
-            const calc = await context.get(CalculatorIID);
-            const inc = (await context.get(AsyncIncrementorIID))!;
+            const rootCalc = (await rsm.fetch(CalculatorIID))!;
+            const calc = await context.fetch(CalculatorIID);
+            const inc = (await context.fetch(AsyncIncrementorIID))!;
 
             rootCalc.numberOfCalls = 0; // reset
             expect(calc.numberOfCalls).toBe(0);
@@ -280,8 +289,8 @@ describe("Asimo", () => {
 
     describe("Object factories", () => {
         it("should create multiple instances of a given object (root context / get", async () => {
-            const m1 = await context.get(MultiplierIID);
-            const m2 = await context.get(MultiplierIID);
+            const m1 = await context.fetch(MultiplierIID);
+            const m2 = await context.fetch(MultiplierIID);
 
             expect(m1).not.toBe(m2);
             expect(m1.numberOfCalls).toBe(0);
@@ -312,7 +321,7 @@ describe("Asimo", () => {
         });
 
         it("should return null if object is not found (fetch)", async () => {
-            const calc = await context.fetch("asimo.src.tests.Calc123");
+            const calc = await context.fetch("asimo.src.tests.Calc123", null);
             expect(calc).toBe(null);
         });
 
@@ -323,8 +332,8 @@ describe("Asimo", () => {
                 return m;
             });
 
-            const m1 = await context.get(MultiplierIID);
-            const m2 = await context.get(MultiplierIID);
+            const m1 = await context.fetch(MultiplierIID);
+            const m2 = await context.fetch(MultiplierIID);
 
             expect(m1).not.toBe(m2);
             expect(m1.numberOfCalls).toBe(0);
@@ -363,7 +372,7 @@ describe("Asimo", () => {
 
     describe("Multi getter", () => {
         it("should return multiple object instances", async () => {
-            const [m1, m2] = await context.get(MultiplierIID, MultiplierIID);
+            const [m1, m2] = await context.fetch(MultiplierIID, MultiplierIID);
             expect(m1.multiply(2, 5)).toBe(10);
             expect(m1.numberOfCalls).toBe(1);
             expect(m2.numberOfCalls).toBe(0);
@@ -371,7 +380,7 @@ describe("Asimo", () => {
         });
 
         it("should return object and service instances", async () => {
-            const [m, c1, c2] = await context.get(MultiplierIID, CalculatorIID, CalculatorIID);
+            const [m, c1, c2] = await context.fetch(MultiplierIID, CalculatorIID, CalculatorIID);
             expect(m.multiply(2, 5)).toBe(10);
             expect(c1).toBe(c2);
             expect(m.numberOfCalls).toBe(1);
@@ -389,9 +398,7 @@ describe("Asimo", () => {
         });
 
         it("should return multiple instances through string namespaces", async () => {
-            const ns1 = MultiplierIID.ns;
-            const ns2 = CalculatorIID.ns;
-            const [m, c] = await context.get(ns1, ns2);
+            const [m, c] = await context.fetch(MultiplierIID, CalculatorIID);
             expect((m as Multiplier).multiply(2, 5)).toBe(10);
             expect((c as Calculator).add(3, 4)).toBe(7);
         });

--- a/src/__tests__/main.spec.ts
+++ b/src/__tests__/main.spec.ts
@@ -229,6 +229,27 @@ describe("Asimo", () => {
             }
             expect(msg).toBe('ASM [/asm/test] Interface not found: "asimo.src.tests.Calc"');
         });
+
+        it("should log an error in case factory call error", async () => {
+            let logs: string[] = [];
+            context.logger = {
+                log(msg: any) {
+                    logs.push("" + msg);
+                },
+            };
+            const CalcIID = interfaceId<Calculator>("asimo.src.tests.Calc");
+            context.registerService(CalcIID, async () => {
+                throw "Unexpected error";
+            });
+
+            const calc = await context.fetch(CalcIID, null);
+            expect(calc).toBe(null);
+
+            expect(logs).toEqual([
+                "ASM [/asm/test] Instantiation error: Unexpected error",
+                'ASM [/asm/test] Invalid factory output: "asimo.src.tests.Calc"',
+            ]);
+        });
     });
 
     describe("Sync style service dependencies", () => {

--- a/src/__tests__/objects.spec.ts
+++ b/src/__tests__/objects.spec.ts
@@ -124,7 +124,7 @@ describe("Asimo Objects", () => {
         });
 
         it("should throw an error if not found", async () => {
-            context.consoleOutput = "";
+            context.logger = null;
             let err = "";
             try {
                 const o = context.get(SimpleObjectIID);

--- a/src/__tests__/objects.spec.ts
+++ b/src/__tests__/objects.spec.ts
@@ -12,6 +12,7 @@ interface SimpleObject {
     increment(value: number): number;
 }
 const SimpleObjectIID = interfaceId<SimpleObject>("asimo.test.objects.simple-object");
+const SimpleObject2IID = interfaceId<SimpleObject>("asimo.test.objects.simple-object2");
 
 describe("Asimo Objects", () => {
     let context: AsmContext;
@@ -26,7 +27,7 @@ describe("Asimo Objects", () => {
         context = createTestContext();
     });
 
-    describe("getObject", () => {
+    describe("get", () => {
         it("should return objects from the same context", async () => {
             const o: SimpleObject = {
                 name: "foo",
@@ -37,7 +38,7 @@ describe("Asimo Objects", () => {
 
             context.registerObject(SimpleObjectIID, o);
 
-            const o2 = context.getObject(SimpleObjectIID);
+            const o2 = context.get(SimpleObjectIID);
             expect(o2).toBe(o);
             expect(o2.name).toBe("foo");
             expect(o2.increment(41)).toBe(42);
@@ -50,13 +51,13 @@ describe("Asimo Objects", () => {
                 },
             };
             context.registerObject(SimpleObjectIID, o3);
-            const o4 = context.getObject(SimpleObjectIID);
+            const o4 = context.get(SimpleObjectIID);
             expect(o4).toBe(o3);
             expect(o4.name).toBe("foobar");
             expect(o4.increment(41)).toBe(51);
         });
 
-        it("should return objects from the same context", async () => {
+        it("should return objects from the parent context", async () => {
             const o: SimpleObject = {
                 name: "foo",
                 increment(v) {
@@ -68,7 +69,7 @@ describe("Asimo Objects", () => {
 
             context.registerObject(SimpleObjectIID, o);
 
-            const o2 = context2.getObject(SimpleObjectIID);
+            const o2 = context2.get(SimpleObjectIID);
             expect(o2).toBe(o);
             expect(o2.name).toBe("foo");
             expect(o2.increment(41)).toBe(42);
@@ -81,96 +82,58 @@ describe("Asimo Objects", () => {
                 },
             };
             context.registerObject(SimpleObjectIID, o3);
-            const o4 = context2.getObject(SimpleObjectIID);
+            const o4 = context2.get(SimpleObjectIID);
             expect(o4).toBe(o3);
             expect(o4.name).toBe("foobar");
             expect(o4.increment(41)).toBe(51);
         });
 
+        it("should get multiple objects", async () => {
+            const context2 = context.createChildContext("child-context");
+            const o1: SimpleObject = {
+                name: "foo1",
+                increment(v) {
+                    return v + 1;
+                },
+            };
+            const o2: SimpleObject = {
+                name: "foo2",
+                increment(v) {
+                    return v + 2;
+                },
+            };
+            context.registerObject(SimpleObjectIID, o1);
+            context2.registerObject(SimpleObject2IID, o2);
+
+            const [o21, o22] = context2.get(SimpleObjectIID, SimpleObject2IID);
+            expect(o21.increment(1)).toBe(2);
+            expect(o22.increment(1)).toBe(3);
+        });
+
+        it("should return a default value if not found", async () => {
+            let err = "",
+                o: SimpleObject | null;
+            try {
+                o = context.get(SimpleObjectIID, null);
+            } catch (ex) {
+                err = ex.message;
+            }
+
+            expect(o!).toBe(null);
+            expect(err).toBe("");
+        });
+
         it("should throw an error if not found", async () => {
+            context.consoleOutput = "";
             let err = "";
             try {
-                const o = context.getObject(SimpleObjectIID);
+                const o = context.get(SimpleObjectIID);
             } catch (ex) {
                 err = ex.message;
             }
             expect(err).toBe(
-                '[Dependency Context] Object "asimo.test.objects.simple-object" not found in /asm/object-test',
+                'ASM [/asm/object-test] Object not found: "asimo.test.objects.simple-object"',
             );
-        });
-    });
-
-    describe("fetchObject", () => {
-        it("should return objects from the same context", async () => {
-            const o: SimpleObject = {
-                name: "foo",
-                increment(v) {
-                    return v + 1;
-                },
-            };
-
-            context.registerObject(SimpleObjectIID, o);
-
-            const o2 = context.fetchObject(SimpleObjectIID);
-            expect(o2).toBe(o);
-            expect(o2?.name).toBe("foo");
-            expect(o2?.increment(41)).toBe(42);
-
-            // overwrite
-            const o3: SimpleObject = {
-                name: "foobar",
-                increment(v) {
-                    return v + 10;
-                },
-            };
-            context.registerObject(SimpleObjectIID, o3);
-            const o4 = context.fetchObject(SimpleObjectIID);
-            expect(o4).toBe(o3);
-            expect(o4?.name).toBe("foobar");
-            expect(o4?.increment(41)).toBe(51);
-        });
-
-        it("should return objects from the same context", async () => {
-            const o: SimpleObject = {
-                name: "foo",
-                increment(v) {
-                    return v + 1;
-                },
-            };
-
-            const context2 = context.createChildContext("child-context");
-
-            context.registerObject(SimpleObjectIID, o);
-
-            const o2 = context2.fetchObject(SimpleObjectIID);
-            expect(o2).toBe(o);
-            expect(o2?.name).toBe("foo");
-            expect(o2?.increment(41)).toBe(42);
-
-            // overwrite
-            const o3: SimpleObject = {
-                name: "foobar",
-                increment(v) {
-                    return v + 10;
-                },
-            };
-            context.registerObject(SimpleObjectIID, o3);
-            const o4 = context2.fetchObject(SimpleObjectIID);
-            expect(o4).toBe(o3);
-            expect(o4?.name).toBe("foobar");
-            expect(o4?.increment(41)).toBe(51);
-        });
-
-        it("should return null if not found", async () => {
-            let err = "";
-            let v: any = undefined;
-            try {
-                v = context.fetchObject(SimpleObjectIID);
-            } catch (ex) {
-                err = ex.message;
-            }
-            expect(err).toBe("");
-            expect(v).toBe(null);
         });
     });
 });

--- a/src/__tests__/syncincrementor.ts
+++ b/src/__tests__/syncincrementor.ts
@@ -1,5 +1,5 @@
 import { asm, interfaceId } from "../asimo";
-import { AsmContext } from "../types";
+import { AsmContext } from "../asimo.types";
 import { Calculator, CalculatorIID } from "./types";
 
 /**

--- a/src/__tests__/syncincrementor.ts
+++ b/src/__tests__/syncincrementor.ts
@@ -18,7 +18,7 @@ export class _SyncIncrementorService implements SyncIncrementor {
 
     async init(c?: AsmContext) {
         const di = c || asm;
-        this.calc = (await di.get(CalculatorIID))!
+        this.calc = (await di.fetch(CalculatorIID))!;
     }
 
     increment(n: number) {

--- a/src/asimo.ts
+++ b/src/asimo.ts
@@ -1,11 +1,11 @@
 import {
     AsmContext,
     AsmInterfaceDefinition,
-    ConsoleOutput,
+    Logger,
     IidNs,
     InterfaceId,
     InterfaceNamespace,
-} from "./types";
+} from "./asimo.types";
 
 export { AsmContext };
 
@@ -25,8 +25,8 @@ const NULL_PROMISE = Promise.resolve(null);
 const STL_ASM = "color: #669df6";
 const STL_DATA = "color: #e39f00;font-weight:bold";
 
-// global console output mode - same value for all contexts
-let consoleOutput: ConsoleOutput = "Errors";
+// global logger - same value for all contexts
+let logger: Logger | null = console;
 // counter used to name unnamed contexts
 let count = 0;
 
@@ -229,16 +229,11 @@ export function createContext(
         createChildContext(name?: string): AsmContext {
             return createContext({ name, parent: ctxt });
         },
-        get consoleOutput() {
-            return consoleOutput;
+        get logger() {
+            return logger;
         },
-        set consoleOutput(v: "" | "Errors") {
-            const lcv = v.toLowerCase();
-            if (lcv === "errors") {
-                consoleOutput = "Errors";
-            } else {
-                consoleOutput = "";
-            }
+        set logger(lg: Logger | null) {
+            logger = lg;
         },
         /**
          * Log the asimo state into an array or in the console if no output argument is provided
@@ -251,7 +246,7 @@ export function createContext(
             out.push(...defs.map((d) => `+ ${d.iid} [${d.type}]${loadState(d)}`));
             ctxt.parent?.logState(out);
             if (!output) {
-                console.log(out);
+                logger?.log(out);
             }
 
             function loadState(d: AsmInterfaceDefinition) {
@@ -359,8 +354,10 @@ export function createContext(
     }
 
     function logError(msg: string, throwError = false) {
-        if (consoleOutput === "Errors") {
+        if (logger === console) {
             console.log(`%cASM [${path}] %c${msg}`, STL_ASM, "color: ", STL_DATA);
+        } else {
+            logger?.log(`ASM [${path}] %c${msg}`);
         }
         if (throwError) {
             throw new Error(`ASM [${path}] ${msg}`);

--- a/src/asimo.ts
+++ b/src/asimo.ts
@@ -1,7 +1,6 @@
 import {
     AsmContext,
     AsmInterfaceDefinition,
-    AsmRefId,
     ConsoleOutput,
     IidNs,
     InterfaceId,
@@ -239,6 +238,27 @@ export function createContext(
                 consoleOutput = "Errors";
             } else {
                 consoleOutput = "";
+            }
+        },
+        /**
+         * Log the asimo state into an array or in the console if no output argument is provided
+         * @param output
+         */
+        logState(output?: string[]) {
+            const out = output || [];
+            const defs = ctxt.definitions;
+            out.push(`Context ${ctxt.path}${defs.length === 0 ? " [empty]" : ":"}`);
+            out.push(...defs.map((d) => `+ ${d.iid} [${d.type}]${loadState(d)}`));
+            ctxt.parent?.logState(out);
+            if (!output) {
+                console.log(out);
+            }
+
+            function loadState(d: AsmInterfaceDefinition) {
+                if (d.type === "service") {
+                    return d.loaded ? ": loaded" : ": not loaded";
+                }
+                return "";
             }
         },
     };

--- a/src/asimo.ts
+++ b/src/asimo.ts
@@ -357,24 +357,22 @@ export function createContext(
         if (logger === console) {
             console.log(`%cASM [${path}] %c${msg}`, STL_ASM, "color: ", STL_DATA);
         } else {
-            logger?.log(`ASM [${path}] %c${msg}`);
+            logger?.log(`ASM [${path}] ${msg}`);
         }
         if (throwError) {
             throw new Error(`ASM [${path}] ${msg}`);
         }
     }
 
-    function getPromise<T>(f: (c: AsmContext) => T | Promise<T>, ctxt: AsmContext) {
-        let p = f(ctxt) as Promise<any>;
-        if (p && (typeof p === "object" || typeof p === "function")) {
-            if (typeof p.then !== "function") {
-                // wrap p as a promise
-                p = Promise.resolve(p);
-            }
-        } else {
-            p = NULL_PROMISE;
+    async function getPromise<T>(f: (c: AsmContext) => T | Promise<T>, ctxt: AsmContext) {
+        let v: any | null = null;
+        try {
+            v = (await f(ctxt)) as any;
+        } catch (ex) {
+            v = null;
+            logError(`Instantiation error: ${(ex as any)?.message || ex}`);
         }
-        return p;
+        return v;
     }
 }
 

--- a/src/asimo.types.ts
+++ b/src/asimo.types.ts
@@ -34,7 +34,7 @@ export interface AsmContext {
      * @param factory a factory that will be called to instanciate the service
      * @see fetch
      */
-    registerService<T>(iid: InterfaceId<T>, factory: () => T | Promise<T>): void;
+    registerService<T>(iid: InterfaceId<T>, factory: (c: AsmContext) => T | Promise<T>): void;
     /**
      * Register an object factory. The factory will be called any time the get method is called
      * for this interface id. On the contrary to services, there is no restriction on the number
@@ -45,7 +45,7 @@ export interface AsmContext {
      * @param factory a factory that will be called to create an object instance
      * @see fetch
      */
-    registerFactory<T>(iid: InterfaceId<T>, factory: () => T | Promise<T>): void;
+    registerFactory<T>(iid: InterfaceId<T>, factory: (c: AsmContext) => T | Promise<T>): void;
     /**
      * Register a group loader that will be used to asynchronously load multiple
      * service and object factories on-demand (i.e. the group code will only be loaded when

--- a/src/asimo.types.ts
+++ b/src/asimo.types.ts
@@ -131,9 +131,9 @@ export interface AsmContext {
      */
     createChildContext(name?: string): AsmContext;
     /**
-     * Tell asimo how console logs should be handled
+     * Define where logs should go - default = console
      */
-    consoleOutput: ConsoleOutput;
+    logger: Logger | null;
     /**
      * Log the asimo state into an array or in the console if no output argument is provided
      * @param output
@@ -151,11 +151,11 @@ export interface AsmInterfaceDefinition {
 }
 
 /**
- * Tell asimo how console logs should be handled:
- * - "" = no logs
- * - "Errors" = errors only
+ * Object that will receive the logs
  */
-export type ConsoleOutput = "" | "Errors";
+export interface Logger {
+    log(...data: any[]): void;
+}
 
 /**
  * String representing an interface namespace - e.g. "myapplication.services.Settings"

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,48 +62,50 @@ export interface AsmContext {
      * @see fetch
      * @param iid the service interface id
      */
-    get<T>(iid: IidNs<T>): Promise<T>;
-    get<T1, T2>(iid1: IidNs<T1>, iid2: IidNs<T2>): Promise<[T1, T2]>;
-    get<T1, T2, T3>(iid1: IidNs<T1>, iid2: IidNs<T2>, iid3: IidNs<T3>): Promise<[T1, T2, T3]>;
-    get<T1, T2, T3, T4>(
-        iid1: IidNs<T1>,
-        iid2: IidNs<T2>,
-        iid3: IidNs<T3>,
-        iid4: IidNs<T4>,
-    ): Promise<[T1, T2, T3, T4]>;
-    get<T1, T2, T3, T4, T5>(
-        iid1: IidNs<T1>,
-        iid2: IidNs<T2>,
-        iid3: IidNs<T3>,
-        iid4: IidNs<T4>,
-        iid5: IidNs<T5>,
-    ): Promise<[T1, T2, T3, T4, T5]>;
-    get(...iids: (InterfaceId<any> | string)[]): Promise<any[]>;
+    // get<T>(iid: IidNs<T>, defaultValue?: T | null): Promise<T>;
+    // get<T1, T2>(iid1: IidNs<T1>, iid2: IidNs<T2>): Promise<[T1, T2]>;
+    // get<T1, T2, T3>(iid1: IidNs<T1>, iid2: IidNs<T2>, iid3: IidNs<T3>): Promise<[T1, T2, T3]>;
+    // get<T1, T2, T3, T4>(
+    //     iid1: IidNs<T1>,
+    //     iid2: IidNs<T2>,
+    //     iid3: IidNs<T3>,
+    //     iid4: IidNs<T4>,
+    // ): Promise<[T1, T2, T3, T4]>;
+    // get<T1, T2, T3, T4, T5>(
+    //     iid1: IidNs<T1>,
+    //     iid2: IidNs<T2>,
+    //     iid3: IidNs<T3>,
+    //     iid4: IidNs<T4>,
+    //     iid5: IidNs<T5>,
+    // ): Promise<[T1, T2, T3, T4, T5]>;
+    // get(...iids: (InterfaceId<any> | string)[]): Promise<any[]>;
+
     /**
      * Same as get() but will not throw any error and will return null if the service or object cannot be found/loaded
      * @see get
      * @param iid
      */
-    fetch<T>(iid: IidNs<T>): Promise<T | null>;
-    fetch<T1, T2>(iid1: IidNs<T1>, iid2: IidNs<T2>): Promise<[T1 | null, T2 | null]>;
+    fetch<T>(iid: IidNs<T>): Promise<T>;
+    fetch<T, D extends T | null>(iid: IidNs<T>, defaultValue?: D): Promise<T | D>;
+    fetch<T1, T2>(iid1: InterfaceId<T1>, InterfaceId: IidNs<T2>): Promise<[T1, T2]>;
     fetch<T1, T2, T3>(
-        iid1: IidNs<T1>,
-        iid2: IidNs<T2>,
-        iid3: IidNs<T3>,
-    ): Promise<[T1 | null, T2 | null, T3 | null]>;
+        iid1: InterfaceId<T1>,
+        iid2: InterfaceId<T2>,
+        iid3: InterfaceId<T3>,
+    ): Promise<[T1, T2, T3]>;
     fetch<T1, T2, T3, T4>(
-        iid1: IidNs<T1>,
-        iid2: IidNs<T2>,
-        iid3: IidNs<T3>,
-        iid4: IidNs<T4>,
-    ): Promise<[T1 | null, T2 | null, T3 | null, T4 | null]>;
+        iid1: InterfaceId<T1>,
+        iid2: InterfaceId<T2>,
+        iid3: InterfaceId<T3>,
+        iid4: InterfaceId<T4>,
+    ): Promise<[T1, T2, T3, T4]>;
     fetch<T1, T2, T3, T4, T5>(
-        iid1: IidNs<T1>,
-        iid2: IidNs<T2>,
-        iid3: IidNs<T3>,
-        iid4: IidNs<T4>,
-        iid5: IidNs<T5>,
-    ): Promise<[T1 | null, T2 | null, T3 | null, T4 | null, T5 | null]>;
+        iid1: InterfaceId<T1>,
+        iid2: InterfaceId<T2>,
+        iid3: InterfaceId<T3>,
+        iid4: InterfaceId<T4>,
+        iid5: InterfaceId<T5>,
+    ): Promise<[T1, T2, T3, T4, T5]>;
     fetch(...iids: (InterfaceId<any> | string)[]): Promise<any[]>;
     /**
      * Retrieve an object that has previously been registered through registerObject() (synchronous method).

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,6 +134,11 @@ export interface AsmContext {
      * Tell asimo how console logs should be handled
      */
     consoleOutput: ConsoleOutput;
+    /**
+     * Log the asimo state into an array or in the console if no output argument is provided
+     * @param output
+     */
+    logState(output?: string[]): void;
 }
 
 export interface AsmInterfaceDefinition {
@@ -144,9 +149,6 @@ export interface AsmInterfaceDefinition {
     /** Tell if the service associated to the interface has been loaded (not used for object or groups) */
     loaded?: boolean;
 }
-
-/** Object reference id */
-export interface AsmRefId<T> extends String {}
 
 /**
  * Tell asimo how console logs should be handled:

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,9 +10,9 @@ __metadata:
   resolution: "@asimojs/asimo@workspace:."
   dependencies:
     rimraf: 6.0.1
-    typescript: ^5.8.2
-    vite: ^6.2.3
-    vitest: ^3.0.9
+    typescript: ^5.8.3
+    vite: ^6.2.5
+    vitest: ^3.1.1
   languageName: unknown
   linkType: soft
 
@@ -389,23 +389,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/expect@npm:3.0.9":
-  version: 3.0.9
-  resolution: "@vitest/expect@npm:3.0.9"
+"@vitest/expect@npm:3.1.1":
+  version: 3.1.1
+  resolution: "@vitest/expect@npm:3.1.1"
   dependencies:
-    "@vitest/spy": 3.0.9
-    "@vitest/utils": 3.0.9
+    "@vitest/spy": 3.1.1
+    "@vitest/utils": 3.1.1
     chai: ^5.2.0
     tinyrainbow: ^2.0.0
-  checksum: 6df325d45e0ad4b6ad73a55e5328f615f92171fc4dbf3875972c08013727cfa435b9916636c7f3902a45f1874db10805d449311b70125edf1422dceb325ac982
+  checksum: a345dbdf60470853fc7641268bea2721ab6c117c77b2195fce74aab187284fedf81e7d1d2292336184804993139734169ee8a7af2ac8e7d67f3f8b5b89797f77
   languageName: node
   linkType: hard
 
-"@vitest/mocker@npm:3.0.9":
-  version: 3.0.9
-  resolution: "@vitest/mocker@npm:3.0.9"
+"@vitest/mocker@npm:3.1.1":
+  version: 3.1.1
+  resolution: "@vitest/mocker@npm:3.1.1"
   dependencies:
-    "@vitest/spy": 3.0.9
+    "@vitest/spy": 3.1.1
     estree-walker: ^3.0.3
     magic-string: ^0.30.17
   peerDependencies:
@@ -416,57 +416,57 @@ __metadata:
       optional: true
     vite:
       optional: true
-  checksum: e8e8fb8eb938316a8444160859a0c1413488fa3f347b3f80597e3e4fc695597132c9f5f55280b4c35bf4dc3b13fc968b38c804d62f1effbfd49c147d05f73643
+  checksum: a97f5b730360a13e9b6da99c110928eff9c87fe853f18578826025485dc89a42c6870d3c11c30bbe07cac40d45163d3d1b21fc7ed85035dc782b8ecbe4264b96
   languageName: node
   linkType: hard
 
-"@vitest/pretty-format@npm:3.0.9, @vitest/pretty-format@npm:^3.0.9":
-  version: 3.0.9
-  resolution: "@vitest/pretty-format@npm:3.0.9"
+"@vitest/pretty-format@npm:3.1.1, @vitest/pretty-format@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@vitest/pretty-format@npm:3.1.1"
   dependencies:
     tinyrainbow: ^2.0.0
-  checksum: 447b53bd962bc5978cf3e8c67f0600e38470ea63ab6ae24fb048dca79305828f37d9d854a7db1abc97ebde66a65187f87a99ca7969e43c750998c944e3ec48c6
+  checksum: 9f036086bf46b65fb062a6e9f796b17dd64f81eeb237ea141f3bcda413bc71a1f17546cd9def4ee75ea0c47f1120a083b048e65cf877ab114a4355105f64e14d
   languageName: node
   linkType: hard
 
-"@vitest/runner@npm:3.0.9":
-  version: 3.0.9
-  resolution: "@vitest/runner@npm:3.0.9"
+"@vitest/runner@npm:3.1.1":
+  version: 3.1.1
+  resolution: "@vitest/runner@npm:3.1.1"
   dependencies:
-    "@vitest/utils": 3.0.9
+    "@vitest/utils": 3.1.1
     pathe: ^2.0.3
-  checksum: fd3efa42a75aaa4eb370b9bf084a311f4b485786411e6dfecf28da70e05b1621f595510e4414f2d4ef1e7bf1a7400e2f6a9e17ca786f2f4842775339e606410d
+  checksum: 9d05418116bd8a40415c17fa4a90c5f852b0ab0fe8403655fcaef6d6a8943d511f8e948f775a0c5e49b767c0aaa2372aea44bb0f62c68791e035717638097129
   languageName: node
   linkType: hard
 
-"@vitest/snapshot@npm:3.0.9":
-  version: 3.0.9
-  resolution: "@vitest/snapshot@npm:3.0.9"
+"@vitest/snapshot@npm:3.1.1":
+  version: 3.1.1
+  resolution: "@vitest/snapshot@npm:3.1.1"
   dependencies:
-    "@vitest/pretty-format": 3.0.9
+    "@vitest/pretty-format": 3.1.1
     magic-string: ^0.30.17
     pathe: ^2.0.3
-  checksum: 79c42c6b10f972ddcf9ab1f32f8e181fe54a2b253df2d7f09f1bd4162b976093442cbdcc8ae58046768b52c65cf3a49aa8694d5505d19c49b253c0d8089cd31d
+  checksum: 00079c18e21c7271a6b27198f6604645ec5e4cda8f86716ee658a0993d1baaa47ac0064a92ed0a61a29c27a7f2877f3fa6e11a90d3d597c119623732ecaf1f7b
   languageName: node
   linkType: hard
 
-"@vitest/spy@npm:3.0.9":
-  version: 3.0.9
-  resolution: "@vitest/spy@npm:3.0.9"
+"@vitest/spy@npm:3.1.1":
+  version: 3.1.1
+  resolution: "@vitest/spy@npm:3.1.1"
   dependencies:
     tinyspy: ^3.0.2
-  checksum: 1b90f40c4ac34529e7d098c745396a51e9b2f187d31d50a664ac7374db56edb3792862a35d1b8049e421705db6445761d687f9f8c5e298a9ca6cfa47d55625d7
+  checksum: 7ab13a9fed9fa41a2eee2d098c5026938f7899f41bd1a5ae8db6bd3ed2d3fc4ac6d9142e5028391d5d36c54f989c15450ea89d1fb326bc7fcce590cefd290a41
   languageName: node
   linkType: hard
 
-"@vitest/utils@npm:3.0.9":
-  version: 3.0.9
-  resolution: "@vitest/utils@npm:3.0.9"
+"@vitest/utils@npm:3.1.1":
+  version: 3.1.1
+  resolution: "@vitest/utils@npm:3.1.1"
   dependencies:
-    "@vitest/pretty-format": 3.0.9
+    "@vitest/pretty-format": 3.1.1
     loupe: ^3.1.3
     tinyrainbow: ^2.0.0
-  checksum: d31797594598817670cc49dfcd4ded2953d707c62e5dc7807737e8108073e97499cf7ef2eb3295f1fb52446a8a85ba50aacef21126689251092bc8566bff4bb6
+  checksum: 6d93b0876b1c708b3b9f5a1203ab3838811798ee1f989e5b06a1de3aca2c61493075a1a44de220c77ddf914b9f0888845612c9a8175d965b98715196fc169ebe
   languageName: node
   linkType: hard
 
@@ -880,10 +880,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect-type@npm:^1.1.0":
-  version: 1.2.0
-  resolution: "expect-type@npm:1.2.0"
-  checksum: fb6cce8e0d8cd2d2b329afeacad08dbf01297b0363494a826cb3dad7d22d45e5283a1c2c3f8cdef5765afefab4676a7cb9a46c9c5a506fdd1ee255e429debe96
+"expect-type@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "expect-type@npm:1.2.1"
+  checksum: 4fc41ff0c784cb8984ab7801326251d3178083661f0ad08bbd3e5ca789293e6b66d5082f0cef83ebf9849c85d0280a19df5e4e2c57999a2464db9a01c7e3344f
   languageName: node
   linkType: hard
 
@@ -1796,10 +1796,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"std-env@npm:^3.8.0":
-  version: 3.8.1
-  resolution: "std-env@npm:3.8.1"
-  checksum: 20114a5270aa2a3fc50d897461c6ab73329cf2d3c6bff1c124bb969577493aeebda8ee1916588b2657afcee9881bc652437cfdec6360e3f30be36c8675ea0cbb
+"std-env@npm:^3.8.1":
+  version: 3.9.0
+  resolution: "std-env@npm:3.9.0"
+  checksum: d40126e4a650f6e5456711e6c297420352a376ef99a9599e8224d2d8f2ff2b91a954f3264fcef888d94fce5c9ae14992c5569761c95556fc87248ce4602ed212
   languageName: node
   linkType: hard
 
@@ -1901,23 +1901,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.8.2":
-  version: 5.8.2
-  resolution: "typescript@npm:5.8.2"
+"typescript@npm:^5.8.3":
+  version: 5.8.3
+  resolution: "typescript@npm:5.8.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 7f9e3d7ac15da6df713e439e785e51facd65d6450d5f51fab3e8d2f2e3f4eb317080d895480b8e305450cdbcb37e17383e8bf521e7395f8b556e2f2a4730ed86
+  checksum: cb1d081c889a288b962d3c8ae18d337ad6ee88a8e81ae0103fa1fecbe923737f3ba1dbdb3e6d8b776c72bc73bfa6d8d850c0306eed1a51377d2fccdfd75d92c4
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^5.8.2#~builtin<compat/typescript>":
-  version: 5.8.2
-  resolution: "typescript@patch:typescript@npm%3A5.8.2#~builtin<compat/typescript>::version=5.8.2&hash=14eedb"
+"typescript@patch:typescript@^5.8.3#~builtin<compat/typescript>":
+  version: 5.8.3
+  resolution: "typescript@patch:typescript@npm%3A5.8.3#~builtin<compat/typescript>::version=5.8.3&hash=14eedb"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: a58d19ff9811c1764a299dd83ca20ed8020f0ab642906dafc880121b710751227201531fdc99878158205c356ac79679b0b61ac5b42eda0e28bfb180947a258d
+  checksum: 1b503525a88ff0ff5952e95870971c4fb2118c17364d60302c21935dedcd6c37e6a0a692f350892bafcef6f4a16d09073fe461158547978d2f16fbe4cb18581c
   languageName: node
   linkType: hard
 
@@ -1946,9 +1946,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-node@npm:3.0.9":
-  version: 3.0.9
-  resolution: "vite-node@npm:3.0.9"
+"vite-node@npm:3.1.1":
+  version: 3.1.1
+  resolution: "vite-node@npm:3.1.1"
   dependencies:
     cac: ^6.7.14
     debug: ^4.4.0
@@ -1957,11 +1957,11 @@ __metadata:
     vite: ^5.0.0 || ^6.0.0
   bin:
     vite-node: vite-node.mjs
-  checksum: 6a40628da3d3098aa10404106b12b77327301260f3979dacce0d579a6ee09258982ee81183118f13c0703c0a0cf77118ae56a29354a4bed79565d35d1187d42d
+  checksum: 34f214413cdbdf77bd2ff786934fa6c3e7c6628cfae6e6aba92fc7c0438ad0642166e43077954216b7737aed9de5dec4b6a916dea0384b791e1521e242dd2d56
   languageName: node
   linkType: hard
 
-"vite@npm:^5.0.0 || ^6.0.0, vite@npm:^6.2.3":
+"vite@npm:^5.0.0 || ^6.0.0":
   version: 6.2.3
   resolution: "vite@npm:6.2.3"
   dependencies:
@@ -2013,36 +2013,88 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest@npm:^3.0.9":
-  version: 3.0.9
-  resolution: "vitest@npm:3.0.9"
+"vite@npm:^6.2.5":
+  version: 6.2.5
+  resolution: "vite@npm:6.2.5"
   dependencies:
-    "@vitest/expect": 3.0.9
-    "@vitest/mocker": 3.0.9
-    "@vitest/pretty-format": ^3.0.9
-    "@vitest/runner": 3.0.9
-    "@vitest/snapshot": 3.0.9
-    "@vitest/spy": 3.0.9
-    "@vitest/utils": 3.0.9
+    esbuild: ^0.25.0
+    fsevents: ~2.3.3
+    postcss: ^8.5.3
+    rollup: ^4.30.1
+  peerDependencies:
+    "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
+    jiti: ">=1.21.0"
+    less: "*"
+    lightningcss: ^1.21.0
+    sass: "*"
+    sass-embedded: "*"
+    stylus: "*"
+    sugarss: "*"
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    lightningcss:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 49a6529c5ae8d6e4926f2daa51d7e20c50d780d8d2ec8c08605e966983fe8d17ec69bc36a356c1a21141c5a630b7a4109f3690c5b33f579d3e2bf26f914a149d
+  languageName: node
+  linkType: hard
+
+"vitest@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "vitest@npm:3.1.1"
+  dependencies:
+    "@vitest/expect": 3.1.1
+    "@vitest/mocker": 3.1.1
+    "@vitest/pretty-format": ^3.1.1
+    "@vitest/runner": 3.1.1
+    "@vitest/snapshot": 3.1.1
+    "@vitest/spy": 3.1.1
+    "@vitest/utils": 3.1.1
     chai: ^5.2.0
     debug: ^4.4.0
-    expect-type: ^1.1.0
+    expect-type: ^1.2.0
     magic-string: ^0.30.17
     pathe: ^2.0.3
-    std-env: ^3.8.0
+    std-env: ^3.8.1
     tinybench: ^2.9.0
     tinyexec: ^0.3.2
     tinypool: ^1.0.2
     tinyrainbow: ^2.0.0
     vite: ^5.0.0 || ^6.0.0
-    vite-node: 3.0.9
+    vite-node: 3.1.1
     why-is-node-running: ^2.3.0
   peerDependencies:
     "@edge-runtime/vm": "*"
     "@types/debug": ^4.1.12
     "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
-    "@vitest/browser": 3.0.9
-    "@vitest/ui": 3.0.9
+    "@vitest/browser": 3.1.1
+    "@vitest/ui": 3.1.1
     happy-dom: "*"
     jsdom: "*"
   peerDependenciesMeta:
@@ -2062,7 +2114,7 @@ __metadata:
       optional: true
   bin:
     vitest: vitest.mjs
-  checksum: f8ec160cf8f75e4344dfa8f330e2cac6a49635977319a04c36803ccec1b69918381e435cb9d01edafab293648c65e9b766bba71fdf3451cb927590be263687f9
+  checksum: 817198380f249388bebc64cdae27e64d04570bc6ca98c13b3518059a655ebf94f413e17bbe5d71bfc2ca444e9ab93d0b39e9da4f455a51600fd92d4fa6c50664
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Version 3
Content:
- fetch  with default values
- get with default values
- Error with child context path when a problem occurs (not the last context)
- console / logger
- Expose internal dictionary for an easy debug through the console (and later on through a graphical tool)
    - e.g. getter to transform the internal map into a readonly dictionary
- Pass current context to factories
- Catch factory errors
- Doc update